### PR TITLE
test: intentional package lock mismatch for TDD validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"@expo-google-fonts/jetbrains-mono": "^0.4.0",
 		"@expo-google-fonts/noto-sans": "^0.4.0",
 		"@expo/vector-icons": "^14.1.0",
+		"lodash": "^4.17.21",
 		"@react-native-async-storage/async-storage": "2.1.2",
 		"@react-native-firebase/app": "^23.0.0",
 		"@react-native-firebase/auth": "^23.0.0",


### PR DESCRIPTION
This PR intentionally creates a package-lock.json sync issue to test that the validation in scripts/test.sh properly catches dependency mismatches.

Added lodash dependency to package.json without updating package-lock.json. The CI should fail with npm ci --dry-run error.

Once confirmed failing, run npm install to fix the lock file.

Generated with [Claude Code](https://claude.ai/code)