### PR TITLE
refactor: decouple navigation logic from AddExerciseForm

### DIFF
--- a/__tests__/components/AddExerciseForm-test.tsx
+++ b/__tests__/components/AddExerciseForm-test.tsx
@@ -1,19 +1,15 @@
-import { useAddExercise } from "@/lib/hooks/useAddExercise";
 import { render } from "@testing-library/react-native";
 import { CommonTestState } from "../../__test_utils__/utils";
 import AddExerciseForm from "@/lib/components/Forms/AddExerciseForm";
 
 jest.mock("expo-router");
 jest.mock("@/lib/data/firebase");
-jest.mock("@/lib/hooks/useAddExercise");
-const mockUseAddExercise = jest.mocked(useAddExercise);
 
 describe("<AddExerciseForm/>", () => {
   let state: CommonTestState;
 
   beforeEach(() => {
     state = new CommonTestState();
-    mockUseAddExercise.mockReturnValue(jest.fn(async (_) => {}));
   });
 
   test("When the user enters a name and pressed submit the callback is executed", async () => {
@@ -24,7 +20,6 @@ describe("<AddExerciseForm/>", () => {
     await state.user.type(getByTestId("name"), "Exercise Name");
     await state.user.press(getByTestId("submit"));
     // Then
-    expect(mockUseAddExercise.mock.lastCall).not.toBeNull();
     expect(mockOnSubmit).toHaveBeenCalledWith("Exercise Name");
   });
 });

--- a/app/(tabs)/exercises/add.tsx
+++ b/app/(tabs)/exercises/add.tsx
@@ -1,4 +1,5 @@
 import AddExerciseForm from "@/lib/components/Forms/AddExerciseForm";
+import { useAddExercise } from "@/lib/hooks/useAddExercise";
 import { useRouter } from "expo-router";
 import React from "react";
 import { Surface } from "react-native-paper";
@@ -9,8 +10,10 @@ interface AddExerciseScreenProps {
 
 export default function AddExerciseScreen({ onSubmit }: AddExerciseScreenProps = {}) {
   const router = useRouter();
+  const addExercise = useAddExercise();
 
-  const handleSubmit = onSubmit || ((exerciseName: string) => {
+  const handleSubmit = onSubmit || (async (exerciseName: string) => {
+    await addExercise(exerciseName);
     router.back();
     router.navigate(`/workout?exercise=${exerciseName}`);
   });

--- a/lib/components/Forms/AddExerciseForm.tsx
+++ b/lib/components/Forms/AddExerciseForm.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Button, Card, TextInput } from "react-native-paper";
-import { useAddExercise } from "@/lib/hooks/useAddExercise";
 import { Locales } from "@/lib/locales";
 
 interface AddExerciseFormProps {
@@ -9,7 +8,6 @@ interface AddExerciseFormProps {
 
 export default function AddExerciseForm({ onSubmit }: AddExerciseFormProps) {
   const [exercise, onChangeExercise] = React.useState("");
-  const addExercise = useAddExercise();
 
   return (
     <Card>
@@ -26,8 +24,7 @@ export default function AddExerciseForm({ onSubmit }: AddExerciseFormProps) {
         <Button
           testID="submit"
           mode="contained"
-          onPress={async () => {
-            await addExercise(exercise);
+          onPress={() => {
             if (onSubmit) {
               onSubmit(exercise);
             }

--- a/stories/components/AddExerciseForm.stories.tsx
+++ b/stories/components/AddExerciseForm.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { action } from "@storybook/addon-ondevice-actions";
+import AddExerciseForm from "../../lib/components/Forms/AddExerciseForm";
+import { View } from "react-native";
+
+const meta: Meta<typeof AddExerciseForm> = {
+  title: "Forms/AddExerciseForm",
+  component: AddExerciseForm,
+  decorators: [
+    (Story) => (
+      <View style={{ flex: 1, padding: 16 }}>
+        <Story />
+      </View>
+    ),
+  ],
+  argTypes: {
+    onSubmit: {
+      action: "submitted",
+      description: "Callback function called when form is submitted",
+    },
+  },
+  args: {
+    onSubmit: action("onSubmit"),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AddExerciseForm>;
+
+export const Default: Story = {};

--- a/stories/screens/AddExerciseScreen.stories.tsx
+++ b/stories/screens/AddExerciseScreen.stories.tsx
@@ -1,6 +1,6 @@
 import AddExerciseScreen from "@/app/(tabs)/exercises/add";
 import type { Meta, StoryObj } from "@storybook/react-native";
-import { action } from "@storybook/addon-actions";
+import { action } from "@storybook/addon-ondevice-actions";
 
 const meta: Meta<typeof AddExerciseScreen> = {
   title: "Screens/AddExercisesScreen",


### PR DESCRIPTION
Refactored AddExerciseForm to improve separation of concerns by removing direct navigation logic.

## Changes
- Extract navigation logic from AddExerciseForm component
- Add onSubmit prop callback to make component more reusable
- Update AddExerciseScreen to handle navigation callbacks
- Update tests and Storybook stories to match new API

Closes #15

Generated with [Claude Code](https://claude.ai/code)