### PR TITLE
fix: migrate from useEmulator to connectFirestoreEmulator

### DIFF
--- a/lib/data/firebase/firebase.native.ts
+++ b/lib/data/firebase/firebase.native.ts
@@ -1,6 +1,7 @@
 import {
 	FirebaseFirestoreTypes,
 	getFirestore,
+	connectFirestoreEmulator,
 } from "@react-native-firebase/firestore";
 
 let initialized = false;
@@ -13,7 +14,7 @@ export function initFirebase(): void {
 
 	db = getFirestore();
 	if (__DEV__ || process.env.EXPO_PUBLIC_USE_EMULATOR) {
-		db.useEmulator("10.0.2.2", 8080);
+		connectFirestoreEmulator(db, "10.0.2.2", 8080);
 	}
 	initialized = true;
 }


### PR DESCRIPTION
Resolves #46

Replace deprecated `db.useEmulator()` with `connectFirestoreEmulator()` in firebase.native.ts to resolve deprecation warning and ensure compatibility with React Native Firebase v22.

## Changes
- Added `connectFirestoreEmulator` to imports
- Replaced `db.useEmulator("10.0.2.2", 8080)` with `connectFirestoreEmulator(db, "10.0.2.2", 8080)`

Generated with [Claude Code](https://claude.ai/code)