### PR TITLE
Configure Android builds to target only arm64 architecture

### DIFF
--- a/app.json
+++ b/app.json
@@ -39,7 +39,15 @@
 				}
 			],
 			"@react-native-firebase/app",
-			"@react-native-firebase/auth"
+			"@react-native-firebase/auth",
+			[
+				"expo-build-properties",
+				{
+					"android": {
+						"architectures": ["arm64-v8a"]
+					}
+				}
+			]
 		],
 		"experiments": {
 			"typedRoutes": true

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"@react-navigation/native": "^7.1.6",
 		"expo": "~53.0.20",
 		"expo-blur": "~14.1.5",
+		"expo-build-properties": "~0.15.2",
 		"expo-constants": "~17.1.7",
 		"expo-dev-client": "~5.2.4",
 		"expo-font": "~13.3.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
 		"@react-navigation/native": "^7.1.6",
 		"expo": "~53.0.20",
 		"expo-blur": "~14.1.5",
-		"expo-build-properties": "~0.15.2",
 		"expo-constants": "~17.1.7",
 		"expo-dev-client": "~5.2.4",
 		"expo-font": "~13.3.2",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"expo-symbols": "~0.4.5",
 		"expo-system-ui": "~5.0.10",
 		"expo-web-browser": "~14.2.0",
+		"expo-build-properties": "~0.12.5",
 		"i18n-js": "^4.5.1",
 		"react": "19.0.0",
 		"react-dom": "19.0.0",


### PR DESCRIPTION
This PR configures Android builds to target only the arm64-v8a architecture, which should reduce build times by ~75% during testing.

## Changes:
- Added expo-build-properties plugin to app.json with arm64-v8a architecture
- Added expo-build-properties dependency to package.json

Fixes #49

Generated with [Claude Code](https://claude.ai/code)