### PR TITLE
fix: update Firestore path to use user-scoped collections

### DIFF
--- a/__tests__/components/AddExerciseForm-test.tsx
+++ b/__tests__/components/AddExerciseForm-test.tsx
@@ -1,4 +1,5 @@
 import { useAddExercise } from "@/lib/hooks/useAddExercise";
+import { useAuth } from "@/lib/hooks/useAuth";
 import { render, screen, waitFor } from "@testing-library/react-native";
 import { CommonTestState } from "../../__test_utils__/utils";
 import AddExerciseForm from "@/lib/components/Forms/AddExerciseForm";
@@ -6,7 +7,9 @@ import AddExerciseForm from "@/lib/components/Forms/AddExerciseForm";
 jest.mock("expo-router");
 jest.mock("@/lib/data/firebase");
 jest.mock("@/lib/hooks/useAddExercise");
+jest.mock("@/lib/hooks/useAuth");
 const mockUseAddExercise = jest.mocked(useAddExercise);
+const mockUseAuth = jest.mocked(useAuth);
 
 describe("<AddExerciseForm/>", () => {
   let state: CommonTestState;
@@ -14,6 +17,16 @@ describe("<AddExerciseForm/>", () => {
   beforeEach(() => {
     state = new CommonTestState();
     mockUseAddExercise.mockReturnValue(jest.fn(async (_) => {}));
+    mockUseAuth.mockReturnValue({
+      user: { uid: "test-user-uid", email: "test@example.com", isAnonymous: false },
+      loading: false,
+      error: null,
+      signInAnonymously: jest.fn(),
+      createAccount: jest.fn(),
+      signIn: jest.fn(),
+      signOut: jest.fn(),
+      clearError: jest.fn(),
+    });
   });
 
   test("When the user enters a name and pressed submit the callback is executed", async () => {

--- a/__tests__/hooks/useExercises-test.tsx
+++ b/__tests__/hooks/useExercises-test.tsx
@@ -16,20 +16,25 @@ describe("useExercises", () => {
   });
 
   test("adding an exercise refreshes the exercise list", async () => {
+    const testUid = "test-user-uid";
+    
     // Mock the subscription method
     mockRepo.subscribeToExercises.mockReturnValue(jest.fn());
 
-    // Render both hooks together
+    // Render both hooks together with UID
     const { result } = renderHook(() => ({
-      exercises: useExercises(),
-      addExercise: useAddExercise(),
+      exercises: useExercises(testUid),
+      addExercise: useAddExercise(testUid),
     }));
 
     // Add a new exercise
     await result.current.addExercise("Push-ups");
 
     // Get the callback that was passed to subscribeToExercises
-    const subscriptionCallback = mockRepo.subscribeToExercises.mock.calls[0][0];
+    const subscriptionCallback = mockRepo.subscribeToExercises.mock.calls[0][1];
+
+    // Verify that the uid was passed correctly
+    expect(mockRepo.subscribeToExercises.mock.calls[0][0]).toBe(testUid);
 
     // Simulate the repo calling back with updated exercise list
     act(() => {

--- a/app/(tabs)/exercises/index.tsx
+++ b/app/(tabs)/exercises/index.tsx
@@ -1,5 +1,6 @@
 import ExerciseList from "@/lib/components/ExerciseList";
 import { useExercises } from "@/lib/hooks/useExercises";
+import { useAuth } from "@/lib/hooks/useAuth";
 import { useRouter } from "expo-router";
 import * as React from "react";
 import { View } from "react-native";
@@ -7,7 +8,8 @@ import { FAB } from "react-native-paper";
 
 export default function ExerciseScreen() {
   const router = useRouter();
-  const { exercises } = useExercises();
+  const { user } = useAuth();
+  const { exercises } = useExercises(user?.uid || "");
   return (
     <View style={{ flex: 1, position: "relative" }} testID="exercise-screen">
       <ExerciseList exercises={exercises} />

--- a/lib/components/Forms/AddExerciseForm.tsx
+++ b/lib/components/Forms/AddExerciseForm.tsx
@@ -2,13 +2,15 @@ import { useRouter } from "expo-router";
 import React from "react";
 import { Button, Card, TextInput } from "react-native-paper";
 import { useAddExercise } from "@/lib/hooks/useAddExercise";
+import { useAuth } from "@/lib/hooks/useAuth";
 import { Locales } from "@/lib/locales";
 
 export default function AddExerciseForm() {
   const [exercise, onChangeExercise] = React.useState("");
   const [isLoading, setIsLoading] = React.useState(false);
   const router = useRouter();
-  const addExercise = useAddExercise();
+  const { user } = useAuth();
+  const addExercise = useAddExercise(user?.uid || "");
 
   return (
     <Card>

--- a/lib/hooks/useAddExercise.ts
+++ b/lib/hooks/useAddExercise.ts
@@ -1,9 +1,12 @@
 import { ExerciseRepo } from "../repo/ExerciseRepo";
 
-export function useAddExercise(): (exercise: string) => Promise<void> {
+export function useAddExercise(uid: string): (exercise: string) => Promise<void> {
   const addExercise = async (exercise: string) => {
+    if (!uid) {
+      throw new Error("User must be authenticated to add exercises");
+    }
     const repo = ExerciseRepo.getInstance();
-    await repo.addExercise(exercise);
+    await repo.addExercise(exercise, uid);
   };
 
   return addExercise;

--- a/lib/hooks/useExercises.ts
+++ b/lib/hooks/useExercises.ts
@@ -2,19 +2,25 @@ import { useEffect, useState } from "react";
 import { Exercise } from "../models/Exercise";
 import { ExerciseRepo } from "../repo/ExerciseRepo";
 
-export const useExercises = () => {
+export const useExercises = (uid: string) => {
   const [exercises, setExercises] = useState<Exercise[]>([]);
 
   useEffect(() => {
+    if (!uid) {
+      console.warn("useExercises: User not authenticated, exercises will be empty");
+      setExercises([]);
+      return;
+    }
+
     const exerciseRepo = ExerciseRepo.getInstance();
-    const unsubscribe = exerciseRepo.subscribeToExercises((exercises) => {
+    const unsubscribe = exerciseRepo.subscribeToExercises(uid, (exercises) => {
       setExercises(exercises);
     });
 
     return () => {
       unsubscribe();
     };
-  }, []);
+  }, [uid]);
 
   return { exercises };
 };

--- a/lib/repo/ExerciseRepo.ts
+++ b/lib/repo/ExerciseRepo.ts
@@ -13,7 +13,6 @@ type Unsubscribe = () => void;
 
 export class ExerciseRepo {
 	private static instance: ExerciseRepo;
-	private readonly collectionName = "exercises"; // Made configurable and more appropriate name
 
 	private constructor() { }
 
@@ -22,6 +21,10 @@ export class ExerciseRepo {
 			ExerciseRepo.instance = new ExerciseRepo();
 		}
 		return ExerciseRepo.instance;
+	}
+
+	private getExercisesCollectionPath(uid: string): string {
+		return `users/${uid}/exercises`;
 	}
 
 	private validateExerciseData(data: unknown): data is Exercise {
@@ -33,38 +36,38 @@ export class ExerciseRepo {
 		);
 	}
 
-	async addExercise(exercise: string): Promise<string> {
+	async addExercise(exercise: string, uid: string): Promise<string> {
 		const startTime = Date.now();
-		console.log(`[ExerciseRepo] Adding exercise: "${exercise}"`);
+		console.log(`[ExerciseRepo] Adding exercise: "${exercise}" for user: ${uid}`);
 		
 		try {
-			const exerciseCollection = collection(getDb(), this.collectionName);
+			const exerciseCollection = collection(getDb(), this.getExercisesCollectionPath(uid));
 			const doc = await addDoc(exerciseCollection, { name: exercise });
 			const duration = Date.now() - startTime;
-			console.log(`[ExerciseRepo] Successfully added exercise "${exercise}" with ID: ${doc.id} (${duration}ms)`);
+			console.log(`[ExerciseRepo] Successfully added exercise "${exercise}" with ID: ${doc.id} for user: ${uid} (${duration}ms)`);
 			return doc.id;
 		} catch (error) {
 			const duration = Date.now() - startTime;
-			console.error(`[ExerciseRepo] Failed to add exercise "${exercise}" after ${duration}ms:`, error);
+			console.error(`[ExerciseRepo] Failed to add exercise "${exercise}" for user: ${uid} after ${duration}ms:`, error);
 			throw error;
 		}
 	}
 
-	async getExerciseById(id: string): Promise<Exercise | undefined> {
+	async getExerciseById(id: string, uid: string): Promise<Exercise | undefined> {
 		const startTime = Date.now();
-		console.log(`[ExerciseRepo] Getting exercise by ID: ${id}`);
+		console.log(`[ExerciseRepo] Getting exercise by ID: ${id} for user: ${uid}`);
 		
 		try {
-			const docRef = doc(getDb(), this.collectionName, id);
+			const docRef = doc(getDb(), this.getExercisesCollectionPath(uid), id);
 
 			const data = await getDoc(docRef).then((snap) => {
 				const data = snap.data();
 				if (data === undefined) {
-					console.log(`[ExerciseRepo] Exercise with ID ${id} not found`);
+					console.log(`[ExerciseRepo] Exercise with ID ${id} not found for user: ${uid}`);
 					return undefined;
 				}
 				if (!this.validateExerciseData(data)) {
-					console.error(`[ExerciseRepo] Invalid exercise data for ID ${id}:`, data);
+					console.error(`[ExerciseRepo] Invalid exercise data for ID ${id} for user: ${uid}:`, data);
 					throw new Error("Invalid exercise data from Firestore");
 				}
 				return { id: snap.id, ...data } as Exercise;
@@ -72,81 +75,81 @@ export class ExerciseRepo {
 			
 			const duration = Date.now() - startTime;
 			if (data) {
-				console.log(`[ExerciseRepo] Successfully retrieved exercise "${data.name}" (ID: ${id}) (${duration}ms)`);
+				console.log(`[ExerciseRepo] Successfully retrieved exercise "${data.name}" (ID: ${id}) for user: ${uid} (${duration}ms)`);
 			} else {
-				console.log(`[ExerciseRepo] Exercise with ID ${id} not found (${duration}ms)`);
+				console.log(`[ExerciseRepo] Exercise with ID ${id} not found for user: ${uid} (${duration}ms)`);
 			}
 			return data;
 		} catch (error) {
 			const duration = Date.now() - startTime;
-			console.error(`[ExerciseRepo] Failed to get exercise by ID ${id} after ${duration}ms:`, error);
+			console.error(`[ExerciseRepo] Failed to get exercise by ID ${id} for user: ${uid} after ${duration}ms:`, error);
 			throw error;
 		}
 	}
 
-	async getExercises(): Promise<Exercise[]> {
+	async getExercises(uid: string): Promise<Exercise[]> {
 		const startTime = Date.now();
-		console.log("[ExerciseRepo] Getting all exercises");
+		console.log(`[ExerciseRepo] Getting all exercises for user: ${uid}`);
 		
 		try {
-			const querySnapshot = await getDocs(collection(getDb(), this.collectionName));
+			const querySnapshot = await getDocs(collection(getDb(), this.getExercisesCollectionPath(uid)));
 			const exercises = querySnapshot.docs.map((doc) => {
 				const data = doc.data();
 				if (!this.validateExerciseData(data)) {
-					console.error(`[ExerciseRepo] Invalid exercise data for doc ${doc.id}:`, data);
+					console.error(`[ExerciseRepo] Invalid exercise data for doc ${doc.id} for user: ${uid}:`, data);
 					throw new Error(`Invalid exercise data from Firestore for doc ${doc.id}`);
 				}
 				return { id: doc.id, ...data } as Exercise;
 			});
 			
 			const duration = Date.now() - startTime;
-			console.log(`[ExerciseRepo] Successfully retrieved ${exercises.length} exercises (${duration}ms)`);
+			console.log(`[ExerciseRepo] Successfully retrieved ${exercises.length} exercises for user: ${uid} (${duration}ms)`);
 			return exercises;
 		} catch (error) {
 			const duration = Date.now() - startTime;
-			console.error(`[ExerciseRepo] Failed to get exercises after ${duration}ms:`, error);
+			console.error(`[ExerciseRepo] Failed to get exercises for user: ${uid} after ${duration}ms:`, error);
 			throw error;
 		}
 	}
 
-	subscribeToExercises(callback: (exercises: Exercise[]) => void): Unsubscribe {
-		console.log("[ExerciseRepo] Setting up real-time subscription to exercises");
+	subscribeToExercises(uid: string, callback: (exercises: Exercise[]) => void): Unsubscribe {
+		console.log(`[ExerciseRepo] Setting up real-time subscription to exercises for user: ${uid}`);
 		
-		const exerciseCollection = collection(getDb(), this.collectionName);
+		const exerciseCollection = collection(getDb(), this.getExercisesCollectionPath(uid));
 		const unsubscribe = onSnapshot(
 			exerciseCollection, 
 			(querySnapshot) => {
 				const startTime = Date.now();
-				console.log("[ExerciseRepo] Real-time update received");
+				console.log(`[ExerciseRepo] Real-time update received for user: ${uid}`);
 				
 				try {
 					const exercises = querySnapshot.docs.map((doc) => {
 						const data = doc.data();
 						if (!this.validateExerciseData(data)) {
-							console.error(`[ExerciseRepo] Invalid exercise data in subscription for doc ${doc.id}:`, data);
+							console.error(`[ExerciseRepo] Invalid exercise data in subscription for doc ${doc.id} for user: ${uid}:`, data);
 							throw new Error(`Invalid exercise data from Firestore for doc ${doc.id}`);
 						}
 						return { id: doc.id, ...data } as Exercise;
 					});
 					
 					const duration = Date.now() - startTime;
-					console.log(`[ExerciseRepo] Processed ${exercises.length} exercises from real-time update (${duration}ms)`);
+					console.log(`[ExerciseRepo] Processed ${exercises.length} exercises from real-time update for user: ${uid} (${duration}ms)`);
 					callback(exercises);
 				} catch (error) {
 					const duration = Date.now() - startTime;
-					console.error(`[ExerciseRepo] Error processing real-time update after ${duration}ms:`, error);
+					console.error(`[ExerciseRepo] Error processing real-time update for user: ${uid} after ${duration}ms:`, error);
 					throw error;
 				}
 			},
 			(error) => {
-				console.error("[ExerciseRepo] Real-time subscription error:", error);
-				console.warn("[ExerciseRepo] Real-time subscription failed, data may not be current");
+				console.error(`[ExerciseRepo] Real-time subscription error for user: ${uid}:`, error);
+				console.warn(`[ExerciseRepo] Real-time subscription failed for user: ${uid}, data may not be current`);
 			}
 		);
 		
-		console.log("[ExerciseRepo] Real-time subscription established");
+		console.log(`[ExerciseRepo] Real-time subscription established for user: ${uid}`);
 		return () => {
-			console.log("[ExerciseRepo] Unsubscribing from real-time updates");
+			console.log(`[ExerciseRepo] Unsubscribing from real-time updates for user: ${uid}`);
 			unsubscribe();
 		};
 	}


### PR DESCRIPTION
Fixes #45 - Production app can't write to firestore

This PR updates the Firestore data path from global `exercises` collection to user-scoped `{uid}/exercises` collections, allowing the app to work with Firestore security rules that require data to be under the `/{uid}/` route.

**Changes:**
- Updated ExerciseRepo to use user-scoped collection paths
- Modified hooks to require user authentication
- Updated components to use user ID from auth
- Enhanced error handling for unauthenticated users
- Updated tests to work with new API

Generated with [Claude Code](https://claude.ai/code)